### PR TITLE
Include svg files in icon list for when png files are not created.

### DIFF
--- a/appimage-desktop-entry.sh
+++ b/appimage-desktop-entry.sh
@@ -23,7 +23,7 @@ cd /tmp/
 cd /tmp/squashfs-root/
 
 echo "Choose icon: "
-FILENAMES=($(ls -d *.png))
+FILENAMES=($(ls -d *.png *.svg))
 i=1
 for filename in ${FILENAMES[*]}
 do


### PR DESCRIPTION
Some appimages create svg files rather than png. This small tweak includes both types in the icon files list to choose from.